### PR TITLE
Update Github Actions criteria

### DIFF
--- a/.github/workflows/ClashOfClansScraper.yaml
+++ b/.github/workflows/ClashOfClansScraper.yaml
@@ -3,9 +3,13 @@ on:
   schedule:
     - cron: 0 0 * * *
   push:
+    branches:
+      - master
+  pull_requests:
     paths:
-    - scraper/**
-    - main.py
+      - scraper/**
+      - main.py
+      - environment.yml
   workflow_dispatch:
 jobs:
   ClashOfClansScraper:

--- a/.github/workflows/ClashOfClansScraper.yaml
+++ b/.github/workflows/ClashOfClansScraper.yaml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - master
-  pull_requests:
+  pull_request:
     paths:
       - scraper/**
       - main.py


### PR DESCRIPTION
Prevent Github Actions from running everytime I push a commit, even when a PR is not created yet.

New criteria for GH Actions:
- On Schedule (daily)
- On merge to master branch
- On PR changes to paths that deal with the scraping workflow.
- On workflow dispatch