### PR TITLE
Run scrape abandoning and login retry

### DIFF
--- a/.github/workflows/ClashOfClansScraper.yaml
+++ b/.github/workflows/ClashOfClansScraper.yaml
@@ -31,6 +31,6 @@ jobs:
           conda list
       - name: "Run Clash of Clans data scraping."
         run: |
-          python main.py --email ${{ secrets.COC_EMAIL }} --password ${{ secrets.COC_PASSWORD }} --name ${{ secrets.AZURE_ACCOUNT_NAME }} --access_key "${{ secrets.AZURE_ACCESS_KEY }}" --connection_string "${{ secrets.AZURE_CONNECTION_STRING }}" --verbosity 3
+          python main.py --email ${{ secrets.COC_EMAIL }} --password ${{ secrets.COC_PASSWORD }} --name ${{ secrets.AZURE_ACCOUNT_NAME }} --access_key "${{ secrets.AZURE_ACCESS_KEY }}" --connection_string "${{ secrets.AZURE_CONNECTION_STRING }}" --verbosity 2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/main.py
+++ b/main.py
@@ -56,9 +56,9 @@ async def main():
     writer = TroopTableHandler(**login_kwargs)
     await writer.process_table()
 
-    # logging.info("Updating Player Table...")
-    # writer = PlayerTableHandler(client, account_name=args.name, access_key=args.access_key, connection_string=args.connection_string)
-    # await writer.process_table()
+    logging.info("Updating Player Table...")
+    writer = PlayerTableHandler(**login_kwargs)
+    await writer.process_table()
 
     # logging.info("Updating Clan Table...")
     # writer = ClanTableHandler(client, account_name=args.name, access_key=args.access_key, connection_string=args.connection_string)

--- a/main.py
+++ b/main.py
@@ -60,9 +60,9 @@ async def main():
     writer = PlayerTableHandler(**login_kwargs)
     await writer.process_table()
 
-    # logging.info("Updating Clan Table...")
-    # writer = ClanTableHandler(client, account_name=args.name, access_key=args.access_key, connection_string=args.connection_string)
-    # await writer.process_table()
+    logging.info("Updating Clan Table...")
+    writer = ClanTableHandler(**login_kwargs)
+    await writer.process_table()
 
     # logging.info("Updating Location Table...")
     # writer = LocationTableHandler(client, account_name=args.name, access_key=args.access_key, connection_string=args.connection_string)

--- a/main.py
+++ b/main.py
@@ -1,6 +1,5 @@
 import argparse
 import asyncio
-import coc
 import logging
 from scraper.gold_pass import GoldPassTableHandler
 from scraper.troops import TroopTableHandler
@@ -41,13 +40,21 @@ async def main():
     logging.basicConfig(format='%(levelname)s - %(asctime)s - %(module)s.%(funcName)s Line %(lineno)d : %(message)s', 
                         level=get_log_level(args.verbosity))
 
+    login_kwargs = {
+        'coc_email': args.email,
+        'coc_password': args.password,
+        'account_name': args.name,
+        'access_key': args.access_key,
+        'connection_string': args.connection_string
+    }
+
     logging.info("Updating Gold Pass Season Table...")
-    writer = GoldPassTableHandler(coc_email=args.email, coc_password=args.password, account_name=args.name, access_key=args.access_key, connection_string=args.connection_string)
+    writer = GoldPassTableHandler(**login_kwargs)
     await writer.process_table()
 
-    # logging.info("Updating Troop Table...")
-    # writer = TroopTableHandler(client, account_name=args.name, access_key=args.access_key, connection_string=args.connection_string)
-    # writer.process_table()
+    logging.info("Updating Troop Table...")
+    writer = TroopTableHandler(**login_kwargs)
+    await writer.process_table()
 
     # logging.info("Updating Player Table...")
     # writer = PlayerTableHandler(client, account_name=args.name, access_key=args.access_key, connection_string=args.connection_string)

--- a/main.py
+++ b/main.py
@@ -41,34 +41,27 @@ async def main():
     logging.basicConfig(format='%(levelname)s - %(asctime)s - %(module)s.%(funcName)s Line %(lineno)d : %(message)s', 
                         level=get_log_level(args.verbosity))
 
-    logging.info("Calling the Clash of Clans client...")
-    client = coc.Client(load_game_data=coc.LoadGameData(default=True))
-    await client.login(args.email, args.password)
-
     logging.info("Updating Gold Pass Season Table...")
-    writer = GoldPassTableHandler(client, account_name=args.name, access_key=args.access_key, connection_string=args.connection_string)
+    writer = GoldPassTableHandler(coc_email=args.email, coc_password=args.password, account_name=args.name, access_key=args.access_key, connection_string=args.connection_string)
     await writer.process_table()
 
-    logging.info("Updating Troop Table...")
-    writer = TroopTableHandler(client, account_name=args.name, access_key=args.access_key, connection_string=args.connection_string)
-    writer.process_table()
+    # logging.info("Updating Troop Table...")
+    # writer = TroopTableHandler(client, account_name=args.name, access_key=args.access_key, connection_string=args.connection_string)
+    # writer.process_table()
 
-    logging.info("Updating Player Table...")
-    writer = PlayerTableHandler(client, account_name=args.name, access_key=args.access_key, connection_string=args.connection_string)
-    await writer.process_table()
+    # logging.info("Updating Player Table...")
+    # writer = PlayerTableHandler(client, account_name=args.name, access_key=args.access_key, connection_string=args.connection_string)
+    # await writer.process_table()
 
-    logging.info("Updating Clan Table...")
-    writer = ClanTableHandler(client, account_name=args.name, access_key=args.access_key, connection_string=args.connection_string)
-    await writer.process_table()
+    # logging.info("Updating Clan Table...")
+    # writer = ClanTableHandler(client, account_name=args.name, access_key=args.access_key, connection_string=args.connection_string)
+    # await writer.process_table()
 
-    logging.info("Updating Location Table...")
-    writer = LocationTableHandler(client, account_name=args.name, access_key=args.access_key, connection_string=args.connection_string)
-    await writer.process_table()
-    await writer.process_clan_scrape()
-    await writer.process_player_scrape()
-
-    logging.info("Closing the Clash of Clans client...")
-    await client.close()
+    # logging.info("Updating Location Table...")
+    # writer = LocationTableHandler(client, account_name=args.name, access_key=args.access_key, connection_string=args.connection_string)
+    # await writer.process_table()
+    # await writer.process_clan_scrape()
+    # await writer.process_player_scrape()
 
 if __name__ == '__main__':
     asyncio.run(main())

--- a/main.py
+++ b/main.py
@@ -64,11 +64,11 @@ async def main():
     writer = ClanTableHandler(**login_kwargs)
     await writer.process_table()
 
-    # logging.info("Updating Location Table...")
-    # writer = LocationTableHandler(client, account_name=args.name, access_key=args.access_key, connection_string=args.connection_string)
-    # await writer.process_table()
-    # await writer.process_clan_scrape()
-    # await writer.process_player_scrape()
+    logging.info("Updating Location Table...")
+    writer = LocationTableHandler(**login_kwargs)
+    await writer.process_table()
+    await writer.process_clan_scrape()
+    await writer.process_player_scrape()
 
 if __name__ == '__main__':
     asyncio.run(main())

--- a/scraper/clans.py
+++ b/scraper/clans.py
@@ -2,14 +2,12 @@ import logging
 import coc
 import datetime
 
-from typing import Dict
-from typing import Union
-from typing import Generator
-from typing import List
+from collections.abc import Iterator
 from scraper import CONFIG
 from scraper.players import PlayerTableHandler
 from scraper.storage import StorageHandler
 from scraper.utils import try_get_attr
+from azure.data.tables import TableEntity
 
 LOGGER = logging.getLogger(__name__)
 
@@ -19,56 +17,42 @@ class ClanTableHandler(StorageHandler):
 
     Attributes
     ----------
-    coc_client : coc.Client
-        The coc client used to connect to the Clash of Clans API.
-    table : str
-        The name of the table to be written to.
+    clans : list[str]
+        The list of clan tags whose data needs to be scraped.
     scrape_enabled : bool
         Whether clan data should be scraped or not.
     member_scrape_enabled : bool
         Whether clan member data should be scraped or not.
-    clans : List[str]
-        The list of clan tags whose data needs to be scraped.
-    kwargs : Dict[str,Union[str,bool]]
-        The kwargs used to initialize the StorageHandler.
+    abandon_scrape_if_entity_exists : bool
+        Determines if the scrape should be abandoned if the entity exists in
+        the table.
 
     Methods
     -------
-    __get_member_tags__(clan: coc.Clan) -> Generator[str,None,None]
-        Returns a generator of the clan's member tags.
-    __scrape_members_data__(clan: coc.Clan) -> None
-        Scrapes the clan's member data by calling PlayerTableHandler.
-    __scrape_members_data_if_needed__(clan: coc.Clan) -> None
-        Scrapes the clan's member data if ClanSettings.MemberScrapeEnabled is True.
-    __convert_data_to_entity_list__(clan: coc.Clan) -> Generator[Dict[str,Union[float,int,str]],None,None]
-        Converts the clan's data to a list of entities.
-    __update_table__(clan: coc.Clan) -> None
-        Updates the table with the clan's data.
+    scrape_location_clans(clans: List[coc.clans.RankedClan]) -> None
+        Scrapes all the clans' data from a specific location.
     process_table() -> None
         Processes the clan table in the database.
     """
 
     configs = CONFIG['ClanSettings']
-    table = configs['TableName']
     clans = configs['Clans']
     scrape_enabled = configs['ScrapeEnabled']
     member_scrape_enabled = configs['MemberScrapeEnabled']
+    abandon_scrape_if_entity_exists = configs['AbandonScrapeIfEntityExists']
 
-    def __init__(self, coc_client: coc.Client, **kwargs) -> None:
+    def __init__(self, **kwargs) -> None:
         """
         Parameters
         ----------
-        coc_client : coc.Client
-            The coc client used to connect to the Clash of Clans API.
-        kwargs : Dict[str,Union[str,bool]]
+        kwargs
             The kwargs used to initialize the StorageHandler.
         """
         
-        super().__init__(self.table, **kwargs)
-        self.coc_client = coc_client
-        self.kwargs = kwargs
+        super().__init__(table_name=self.configs['TableName'], **kwargs)
+        self.__login_kwargs = kwargs
 
-    def __get_member_tags__(self, clan: coc.Clan) -> Generator[str,None,None]:
+    def __get_member_tags(self, clan: coc.Clan) -> Iterator[str]:
         """
         Returns an iterator of the clan's member tags.
 
@@ -77,10 +61,10 @@ class ClanTableHandler(StorageHandler):
         clan : coc.Clan
             The clan whose member tags need to be scraped.
 
-        Returns
-        -------
-        Generator[str,None,None]
-            An iterator of the clan's member tags.
+        Yields
+        ------
+        str
+            The clan's member tags.
         """
 
         assert isinstance(clan, coc.Clan)
@@ -88,7 +72,57 @@ class ClanTableHandler(StorageHandler):
         for member in try_get_attr(clan, 'members'):
             yield try_get_attr(member, 'tag')
 
-    async def __scrape_members_data__(self, clan: coc.Clan) -> None:
+    def __get_partition_key(self, clan_tag: str) -> str:
+        """
+        Gets the partition key for the clan, i.e. the clan tag.
+
+        Parameters
+        ----------
+        clan_tag : str
+            The clan tag whose partition key needs to be retrieved.
+
+        Returns
+        -------
+        str
+            The partition key for the clan.
+        """
+
+        return clan_tag.lstrip('#')
+
+    def __get_row_key(self) -> str:
+        """
+        Gets the row key for the clan.
+
+        Returns
+        -------
+        str
+            The row key for the clan in the current month.
+        """
+
+        return datetime.datetime.now().strftime('%Y-%m-%d')
+
+    def __does_clan_data_exist(self, clan_tag: str) -> bool:
+        """
+        Determines if the clan's data already exists in the table.
+
+        Parameters
+        ----------
+        clan_tag : str
+            The clan tag whose data needs to be checked.
+
+        Returns
+        -------
+        bool
+            True if the clan's data exists in the table, else False.
+        """
+
+        LOGGER.debug(f'Checking if entity exists in table {self.table_name}.')
+        partition_key = self.__get_partition_key(clan_tag)
+        row_key = self.__get_row_key()
+        entity = self.try_get_entity(partition_key, row_key, select='PartitionKey', retries_remaining=self.retry_entity_extraction_count)
+        return entity is not None
+
+    async def __scrape_members_data(self, clan: coc.Clan) -> None:
         """
         Scrapes the clan's member data by calling PlayerTableHandler.
         
@@ -96,33 +130,47 @@ class ClanTableHandler(StorageHandler):
         ----------
         clan : coc.Clan
             The clan whose member data needs to be scraped.
+
+        Returns
+        -------
+        None
         """
 
         assert isinstance(clan, coc.Clan)
 
-        scraper = PlayerTableHandler(self.coc_client, **self.kwargs)
-        member_tags = self.__get_member_tags__(clan)
+        scraper = PlayerTableHandler(**self.__login_kwargs)
+        member_tags = self.__get_member_tags(clan)
         await scraper.scrape_clan_members(member_tags)
 
-    async def __scrape_members_data_if_needed__(self, clan: coc.Clan) -> None:
+    async def __scrape_members_data_if_needed(self, clan: coc.Clan) -> None:
         """
-        Scrapes the clan's member data if ClanSettings.MemberScrapeEnabled is True.
+        Scrapes the clan's member data if ClanSettings.MemberScrapeEnabled 
+        is True.
         
         Parameters
         ----------
         clan : coc.Clan
             The clan whose member data needs to be scraped.
+
+        Returns
+        -------
+        None
         """
+
+        should_abandon_scrape = self.abandon_scrape_if_entity_exists and self.__does_clan_data_exist(try_get_attr(clan, 'tag'))
+        if should_abandon_scrape:
+            LOGGER.info(f'Abandoning member scrape for the clan {try_get_attr(clan, "tag")} because the clan data already exists.')
+            return None
 
         if self.member_scrape_enabled:
             assert isinstance(clan, coc.Clan)
 
             LOGGER.debug(f'Scraping members data for clan {try_get_attr(clan, "tag")}.')
-            await self.__scrape_members_data__(clan)
+            await self.__scrape_members_data(clan)
         else:
             LOGGER.debug(f'Not scraping members data for clan {try_get_attr(clan, "tag")} because ClanSettings.MemberScrapeEnabled is {self.member_scrape_enabled}.')
 
-    def __convert_data_to_entity_list__(self, clan: coc.Clan) -> Generator[Dict[str,Union[float,int,str]],None,None]:
+    def __convert_data_to_entity_list(self, clan: coc.Clan) -> Iterator[TableEntity]:
         """
         Converts the given data to a list of entities to insert/upsert to
         the table.
@@ -132,16 +180,16 @@ class ClanTableHandler(StorageHandler):
         clan : coc.Clan
             The clan whose data needs to be converted.
 
-        Returns
+        Yields
         -------
-        Generator[Dict[str,Union[float,int,str]],None,None]
-            A generator of entities to insert/upsert to the table.
+        azure.data.tables.TableEntity
+            The entities to insert/upsert to the table.
         """
 
-        entity = dict()
+        entity = TableEntity()
 
-        entity['PartitionKey'] = try_get_attr(clan, 'tag').lstrip('#')
-        entity['RowKey'] = datetime.datetime.now().strftime('%Y-%m-%d')
+        entity['PartitionKey'] = self.__get_partition_key(try_get_attr(clan, 'tag'))
+        entity['RowKey'] = self.__get_row_key()
         entity['Name'] = try_get_attr(clan, 'name')
         entity['Tag'] = try_get_attr(clan, 'tag')
         entity['Level'] = try_get_attr(clan, 'level')
@@ -161,7 +209,7 @@ class ClanTableHandler(StorageHandler):
 
         yield entity
 
-    def __update_table__(self, clan: coc.Clan) -> None:
+    def __update_table(self, clan: coc.Clan) -> None:
         """
         Updates the table with the clan's data.
 
@@ -169,46 +217,92 @@ class ClanTableHandler(StorageHandler):
         ----------
         clan : coc.Clan
             The clan whose data needs to be updated.
+
+        Returns
+        -------
+        None
         """
 
-        # TODO: How to prevent data scraping if data is already present in the table?
-        entities = self.__convert_data_to_entity_list__(clan)
+        entities = self.__convert_data_to_entity_list(clan)
         self.write_data_to_table(entities=entities)
 
-    async def scrape_location_clans(self, clans: List[coc.clans.RankedClan]) -> None:
+    async def scrape_location_clans(self, clans: list[coc.clans.RankedClan], coc_client_handling: bool = True) -> None:
         """
         Scrapes the given location's clans.
 
         Parameters
         ----------
-        clan_tags : List[RankedClan]
+        clan_tags : list[RankedClan]
             The list of ranked clans to scrape.
+        coc_client_handling : bool, optional
+            (Default: True) Whether or not to handle the coc client session
+            automatically.
+
+        Returns
+        -------
+        None
         """
 
+        if coc_client_handling:
+            await self.start_coc_client_session()
+
         for clan in clans:
+            should_abandon_scrape = self.abandon_scrape_if_entity_exists and self.__does_clan_data_exist(try_get_attr(clan, 'tag'))
+            if should_abandon_scrape:
+                LOGGER.info(f'Abandoning member scrape for the clan {try_get_attr(clan, "tag")} because the clan data already exists.')
+                continue
+
             try:
                 LOGGER.debug(f'Scraping clan {try_get_attr(clan, "tag")}.')
                 clan = await self.coc_client.get_clan(try_get_attr(clan, 'tag')) if not isinstance(clan, coc.Clan) else clan
-                self.__update_table__(clan)
-                await self.__scrape_members_data_if_needed__(clan)
+                self.__update_table(clan)
+                await self.__scrape_members_data_if_needed(clan)
             except Exception as ex:
                 LOGGER.error(f'Error while scraping clan {try_get_attr(clan, "tag")}: {ex}')
                 LOGGER.error(str(ex))
 
-    async def process_table(self) -> None:
+        if coc_client_handling:
+                await self.close_coc_client_session()
+
+    async def process_table(self, coc_client_handling: bool = True) -> None:
         """
         Processes the clan table in the database.
+
+        Parameters
+        ----------
+        coc_client_handling : bool, optional
+            (Default: True) Whether or not to handle the coc client session
+            automatically.
+
+        Returns
+        -------
+        None
         """
 
+        if coc_client_handling:
+            await self.start_coc_client_session()
+
         if self.scrape_enabled:
-            LOGGER.info(f'Clan table {self.table} is updating.')
+            # Abandon scrape of clan if the clan data already exists.
+            # Loop through the clan tags in reverse order so that pop() will not 
+            # affect the order of the tags.
+            for i in reversed(range(len(self.clans))):
+                should_abandon_scrape = self.abandon_scrape_if_entity_exists and self.__does_clan_data_exist(self.clans[i])
+                if should_abandon_scrape:
+                    LOGGER.info(f'Abandoning member scrape for the clan {self.clans[i]} because the clan data already exists.')
+                    self.clans.pop(i)
+
+            LOGGER.info(f'Clan table {self.table_name} is updating.')
             async for clan in self.coc_client.get_clans(self.clans):
                 try:
                     LOGGER.debug(f'Updating table with clan {clan} data.')
-                    self.__update_table__(clan)
-                    await self.__scrape_members_data_if_needed__(clan)
+                    self.__update_table(clan)
+                    await self.__scrape_members_data_if_needed(clan)
                 except Exception as ex:
                     LOGGER.error(f'Unable to update table with clan {clan} data.')
                     LOGGER.error(str(ex))
         else:
-            LOGGER.info(f'Clan table {self.table} is not updated because ClanSettings.ScrapeEnabled is {self.scrape_enabled}.')
+            LOGGER.info(f'Clan table {self.table_name} is not updated because ClanSettings.ScrapeEnabled is {self.scrape_enabled}.')
+
+        if coc_client_handling:
+            await self.close_coc_client_session()

--- a/scraper/clans.py
+++ b/scraper/clans.py
@@ -138,9 +138,9 @@ class ClanTableHandler(StorageHandler):
 
         assert isinstance(clan, coc.Clan)
 
-        scraper = PlayerTableHandler(**self.__login_kwargs)
+        scraper = PlayerTableHandler(coc_client=self.coc_client, **self.__login_kwargs)
         member_tags = self.__get_member_tags(clan)
-        await scraper.scrape_clan_members(member_tags)
+        await scraper.scrape_clan_members(member_tags, coc_client_handling=False)
 
     async def __scrape_members_data_if_needed(self, clan: coc.Clan) -> None:
         """

--- a/scraper/clans.py
+++ b/scraper/clans.py
@@ -162,7 +162,7 @@ class ClanTableHandler(StorageHandler):
 
         # TODO: How to prevent data scraping if data is already present in the table?
         entities = self.__convert_data_to_entity_list__(clan)
-        self.__write_data_to_table__(entities=entities)
+        self.write_data_to_table(entities=entities)
 
     async def process_table(self) -> None:
         """

--- a/scraper/config.yaml
+++ b/scraper/config.yaml
@@ -45,5 +45,5 @@ LocationSettings:
   Locations: [32000144, 32000209]
   ClanScrapeByLocationEnabled: true
   ClanScrapeLimit: 10
-  PlayerScrapeByLocationEnabled: false
+  PlayerScrapeByLocationEnabled: true
   PlayerScrapeLimit: 10

--- a/scraper/config.yaml
+++ b/scraper/config.yaml
@@ -43,6 +43,7 @@ ClanSettings:
 LocationSettings:
   TableName: "Location"
   ScrapeEnabled: true
+  AbandonScrapeIfEntityExists: true
   # Location data to be scraped.
   #   1: 32000144
   #   2: 32000209

--- a/scraper/config.yaml
+++ b/scraper/config.yaml
@@ -1,4 +1,8 @@
 StorageHandlerSettings:
+  RetryEntityCreationEnabled: true
+  RetryEntityCreationCount: 1
+  RetryEntityExtractionEnabled: true
+  RetryEntityExtractionCount: 1
   UpsertAtFailedPushEnabled: true
 
 TroopSettings:

--- a/scraper/config.yaml
+++ b/scraper/config.yaml
@@ -5,15 +5,18 @@ TroopSettings:
   TableName: "Troop"
   Categories: ["hero", "pet", "home_troop", "super_troop", "builder_troop", "spell"]
   ScrapeEnabled: true
+  AbandonScrapeIfEntityExists: true
   NullIdScrapeEnabled: false
 
 GoldPassSettings:
   TableName: "GoldPass"
   ScrapeEnabled: true
+  AbandonScrapeIfEntityExists: true
 
 PlayerSettings:
   TableName: "Player"
   ScrapeEnabled: true
+  AbandonScrapeIfEntityExists: true
   # Player data to be scraped.
   #   zoecmy: #QPPLYYJGY
   Players: ["#QPPLYYJGY"]
@@ -21,6 +24,7 @@ PlayerSettings:
 ClanSettings:
   TableName: "Clan"
   ScrapeEnabled: true
+  AbandonScrapeIfEntityExists: true
   # Clan data to be scraped.
   #   ATAS: #9J82VUV
   #     includes:

--- a/scraper/gold_pass.py
+++ b/scraper/gold_pass.py
@@ -121,12 +121,12 @@ class GoldPassTableHandler(StorageHandler):
         duration = try_get_attr(data, 'duration', default=None)
 
         entity = TableEntity()
-        entity.PartitionKey = self.__get_partition_key()
-        entity.RowKey = self.__get_row_key()
-        entity.SeasonId = datetime.datetime.now().strftime('%Y%m')
-        entity.StartTime = start_time.time if start_time is not None else None
-        entity.EndTime = end_time.time if end_time is not None else None
-        entity.Duration = self.__convert_timedelta_to_days(duration) if duration is not None else None
+        entity['PartitionKey'] = self.__get_partition_key()
+        entity['RowKey'] = self.__get_row_key()
+        entity['SeasonId'] = datetime.datetime.now().strftime('%Y%m')
+        entity['StartTime'] = start_time.time if start_time is not None else None
+        entity['EndTime'] = end_time.time if end_time is not None else None
+        entity['Duration'] = self.__convert_timedelta_to_days(duration) if duration is not None else None
         yield entity
 
     async def __get_data(self, retries_remaining: int = 0) -> coc.miscmodels.GoldPassSeason:

--- a/scraper/gold_pass.py
+++ b/scraper/gold_pass.py
@@ -2,11 +2,11 @@ import logging
 import coc
 import datetime
 
-from typing import Dict
-from typing import Union
-from typing import Generator
+from collections.abc import Iterator
 from scraper import CONFIG
 from scraper.storage import StorageHandler
+from scraper.utils import try_get_attr
+from azure.data.tables import TableEntity
 
 LOGGER = logging.getLogger(__name__)
     
@@ -17,21 +17,14 @@ class GoldPassTableHandler(StorageHandler):
 
     Attributes
     ----------
-    coc_client : coc.Client
-        The client used to access the Clash of Clans API.
-    table : str
-        The name of the table.
     scrape_enabled : bool
         Determines if data scraping should be performed.
+    abandon_scrape_if_entity_exists : bool
+        Determines if the scrape should be abandoned if the entity exists in
+        the table.
     
     Methods
     -------
-    __convert_timedelta_to_days__(dt: datetime.timedelta) -> float
-        Converts the given timedelta to days.
-    __convert_data_to_entity_list__(data: coc) -> Generator[Dict[str,Union[float,int,str]],None,None]
-        Converts the given data to an enumerable of entities.
-    __update_table__() -> None
-        Updates the table with the current Gold Pass Season data.
     process_table() -> None
         Public API to update the table with the current Gold Pass Season data.
     """
@@ -44,13 +37,13 @@ class GoldPassTableHandler(StorageHandler):
         """
         Parameters
         ----------
-        coc_client : coc.Client
-            The client used to access the Clash of Clans API.
+        **kwargs
+            Keyword arguments to pass to the StorageHandler class.
         """
 
         super().__init__(table_name=self.configs['TableName'], **kwargs)
 
-    def __does_entity_exist__(self) -> bool:
+    def __does_entity_exist(self) -> bool:
         """
         Determines if the entity exists in the table.
 
@@ -61,12 +54,12 @@ class GoldPassTableHandler(StorageHandler):
         """
 
         LOGGER.debug(f'Checking if entity exists in table {self.table_name}.')
-        partition_key = self.__get_partition_key__()
-        row_key = self.__get_row_key__()
-        entity = self.try_get_entity(partition_key, row_key, select='PartitionKey')
+        partition_key = self.__get_partition_key()
+        row_key = self.__get_row_key()
+        entity = self.try_get_entity(partition_key, row_key, select='PartitionKey', retries_remaining=self.retry_entity_extraction_count)
         return entity is not None
 
-    def __convert_timedelta_to_days__(self, dt: datetime.timedelta) -> float:
+    def __convert_timedelta_to_days(self, dt: datetime.timedelta) -> float:
         """
         Converts the given timedelta to days.
 
@@ -83,7 +76,7 @@ class GoldPassTableHandler(StorageHandler):
 
         return dt / datetime.timedelta(days=1)
 
-    def __get_partition_key__(self) -> str:
+    def __get_partition_key(self) -> str:
         """
         Gets the partition key for the current month, i.e. the current year.
 
@@ -95,7 +88,7 @@ class GoldPassTableHandler(StorageHandler):
 
         return datetime.datetime.now().strftime('%Y')
 
-    def __get_row_key__(self) -> str:
+    def __get_row_key(self) -> str:
         """
         Gets the row key for the current month, i.e. the current month.
 
@@ -107,49 +100,111 @@ class GoldPassTableHandler(StorageHandler):
 
         return datetime.datetime.now().strftime('%m')
 
-    def __convert_data_to_entity_list__(self, data: coc.miscmodels.GoldPassSeason) -> Generator[Dict[str,Union[float,int,str]],None,None]:
+    def __convert_data_to_entity_list(self, data: coc.miscmodels.GoldPassSeason) -> Iterator[TableEntity]:
         """
-        Converts the given data to an enumerable of entities.
+        Converts the given data to an iterable of entities.
 
         Parameters
         ----------
         data : coc.miscmodels.GoldPassSeason
             The data to convert.
 
-        Returns
-        -------
-        Generator[Dict[str,Union[float,int,str]],None,None]
+        Yields
+        ------
+        azure.data.tables.TableEntity
             The data converted to an enumerable of entities.
         """
 
         LOGGER.debug(f'Creating entity for Gold Pass Season.')
-        entity = dict()
-        entity['PartitionKey'] = self.__get_partition_key__()
-        entity['RowKey'] = self.__get_row_key__()
-        entity['SeasonId'] = datetime.datetime.now().strftime('%Y-%m')
-        entity['StartTime'] = data.start_time.time
-        entity['EndTime'] = data.end_time.time
-        entity['Duration'] = self.__convert_timedelta_to_days__(data.duration)
+        start_time = try_get_attr(data, 'start_time', default=None)
+        end_time = try_get_attr(data, 'end_time', default=None)
+        duration = try_get_attr(data, 'duration', default=None)
+
+        entity = TableEntity()
+        entity.PartitionKey = self.__get_partition_key()
+        entity.RowKey = self.__get_row_key()
+        entity.SeasonId = datetime.datetime.now().strftime('%Y%m')
+        entity.StartTime = start_time.time if start_time is not None else None
+        entity.EndTime = end_time.time if end_time is not None else None
+        entity.Duration = self.__convert_timedelta_to_days(duration) if duration is not None else None
         yield entity
 
-    async def __update_table__(self) -> None:
+    async def __get_data(self, retries_remaining: int = 0) -> coc.miscmodels.GoldPassSeason:
         """
-        Scrape and update the table with the current Gold Pass Season data.
+        Gets the current Gold Pass Season data.
+
+        Parameters
+        ----------
+        retries_remaining : int, optional
+            (Default: 0) The number of retries remaining.
+
+        Raises
+        ------
+        coc.errors.Forbidden
+            If the client is not authorized to access the data.
+
+        Returns
+        -------
+        coc.miscmodels.GoldPassSeason
+            The current Gold Pass Season data.
         """
 
-        should_abandon_scrape = self.abandon_scrape_if_entity_exists and self.__does_entity_exist__()
+        assert retries_remaining >= 0, 'retries_remaining must be greater than or equal to 0.'
+        try:
+            LOGGER.debug('Getting Gold Pass data.')
+            return await self.coc_client.get_current_goldpass_season()
+        except coc.errors.Forbidden as ex:
+            LOGGER.error(f'Encountered Forbidden error while getting Gold Pass data.')
+            
+            if retries_remaining > 0:
+                LOGGER.debug(f'Retrying getting Gold Pass data.  Retries remaining: {retries_remaining}.')
+                await self.restart_coc_client_session()
+                return await self.__get_data(retries_remaining-1)
+            else:
+                raise ex
+
+    async def __update_table(self) -> None:
+        """
+        Scrape and update the table with the current Gold Pass Season data.
+
+        Raises
+        ------
+        coc.errors.Forbidden
+            If the client is not authorized to access the data.
+
+        Returns
+        -------
+        None
+        """
+
+        should_abandon_scrape = self.abandon_scrape_if_entity_exists and self.__does_entity_exist()
         if should_abandon_scrape:
             LOGGER.info(f'Abandoning scrape because entity exists in table {self.table_name} and GoldPassSettings.AbandonScrapeIfEntityExists is {self.abandon_scrape_if_entity_exists}.')
             return None
 
         LOGGER.debug('Scraping Gold Pass data.')
-        data = await self.coc_client.get_current_goldpass_season()
-        entities = self.__convert_data_to_entity_list__(data)
+        data = await self.__get_data()
+        entities = self.__convert_data_to_entity_list(data)
         self.write_data_to_table(entities=entities)
 
     async def process_table(self, coc_client_handling: bool = True) -> None:
         """
         Public API to update the table with the current Gold Pass Season data.
+
+        Parameters
+        ----------
+        coc_client_handling : bool, optional
+            (Default: True) Whether or not to handle the coc client session
+            automatically.
+
+        Raises
+        ------
+        coc.errors.Forbidden
+            If the client is not authorized to access the data.
+
+        Returns
+        -------
+        None
         """
 
         if coc_client_handling:
@@ -158,7 +213,7 @@ class GoldPassTableHandler(StorageHandler):
         if self.scrape_enabled:
             try:
                 LOGGER.info(f'Gold Pass table {self.table_name} is updating.')
-                await self.__update_table__()
+                await self.__update_table()
             except Exception as ex:
                 LOGGER.error(f'Unable to update table with Gold Pass Season data.')
                 LOGGER.error(str(ex))

--- a/scraper/locations.py
+++ b/scraper/locations.py
@@ -202,8 +202,8 @@ class LocationTableHandler(StorageHandler):
                 for location in self.locations:
                     LOGGER.info(f"Scraping {self.clan_scrape_limit} clans in {location}.")
                     clans = await self.coc_client.get_location_clans(location_id=location, limit=self.clan_scrape_limit)
-                    writer = ClanTableHandler(**self.__login_kwargs)
-                    await writer.scrape_location_clans(clans)
+                    writer = ClanTableHandler(coc_client=self.coc_client, **self.__login_kwargs)
+                    await writer.scrape_location_clans(clans, coc_client_handling=False)
             except Exception as ex:
                 LOGGER.error("Error occurred while scraping clans by location.")
                 LOGGER.error(str(ex))
@@ -235,8 +235,8 @@ class LocationTableHandler(StorageHandler):
                 for location in self.locations:
                     LOGGER.info(f"Scraping {self.player_scrape_limit} players in {location}.")
                     players = await self.coc_client.get_location_players(location_id=location, limit=self.player_scrape_limit)
-                    writer = PlayerTableHandler(**self.__login_kwargs)
-                    await writer.scrape_location_players(players)
+                    writer = PlayerTableHandler(coc_client=self.coc_client, **self.__login_kwargs)
+                    await writer.scrape_location_players(players, coc_client_handling=False)
             except Exception as ex:
                 LOGGER.error("Error occurred while scraping players by location.")
                 LOGGER.error(str(ex))

--- a/scraper/players.py
+++ b/scraper/players.py
@@ -91,7 +91,7 @@ class PlayerTableHandler(StorageHandler):
 
         # Mandatory keys
         # PartitionKey to be defined as '{PlayerTag}-{TroopId}' when extracting troop details
-        entity['RowKey'] = datetime.datetime.now().strftime('%Y-%m-%d')
+        entity['RowKey'] = self.__get_row_key()
 
         # Identity keys
         entity['SeasonId'] = datetime.datetime.now().strftime('%Y-%m')
@@ -209,6 +209,18 @@ class PlayerTableHandler(StorageHandler):
         data = await self.coc_client.get_player(player_tag=player)
         return self.__convert_data_to_entity_list(data)
 
+    def __get_row_key(self) -> str:
+        """
+        Gets the row key for the player.
+
+        Returns
+        -------
+        str
+            The row key for the player in the current month.
+        """
+
+        return datetime.datetime.now().strftime('%Y-%m-%d')
+
     def __does_player_data_exist(self, player: str) -> bool:
         """
         Checks if the player data exists in the table.
@@ -226,7 +238,7 @@ class PlayerTableHandler(StorageHandler):
 
         LOGGER.debug(f'Checking if {player} exists in table {self.table_name}.')
         
-        row_key = datetime.datetime.now().strftime('%Y-%m-%d')
+        row_key = self.__get_row_key()
 
         query_filter = f"RowKey eq '{row_key}' and Tag eq '{player}'"
         results = self.try_query_entities(query_filter=query_filter, retries_remaining=self.retry_entity_extraction_count, select='PartitionKey')

--- a/scraper/players.py
+++ b/scraper/players.py
@@ -262,7 +262,7 @@ class PlayerTableHandler(StorageHandler):
 
         should_abandon_scrape = self.abandon_scrape_if_entity_exists and self.__does_player_data_exist(player)
         if should_abandon_scrape:
-            LOGGER.info(f'Abandoning scrape for {player} in because it already exists.')
+            LOGGER.info(f'Abandoning scrape for {player} because it already exists.')
             return None
 
         entities = await self.__get_data(player)

--- a/scraper/players.py
+++ b/scraper/players.py
@@ -2,13 +2,11 @@ import logging
 import coc
 import datetime
 
-from typing import Dict
-from typing import Union
-from typing import List
-from typing import Generator
+from collections.abc import Iterator
 from scraper import CONFIG
 from scraper.storage import StorageHandler
 from scraper.utils import try_get_attr
+from azure.data.tables import TableEntity
 
 LOGGER = logging.getLogger(__name__)
 
@@ -21,59 +19,40 @@ class PlayerTableHandler(StorageHandler):
 
     Attributes
     ----------
-    coc_client : coc.Client
-        The client used to connect to the Clash of Clans API.
-    entity : dict
-        The current entity to be written to the table.
-    table : str
-        The name of the table to be written to.
+    players : list[str]
+        A list of player tags whose data needs to be scraped.
     scrape_enabled : bool
         Whether player data should be scraped or not.
-    players : list
-        A list of player tags whose data needs to be scraped.
+    abandon_scrape_if_entity_exists : bool
+        Determines if the scrape should be abandoned if the entity exists in
+        the table.
 
     Methods
     -------
-    __try_get_attr__(data: coc.abc.BasePlayer, attr: str, index: Optional[int] = None) -> Union[float,int,str]
-        Tries to get an attribute from the data object. If the attribute 
-        is not found, returns None.
-    __is_super_troop_active__(troop: coc.abc.DataContainer, data: coc.abc.BasePlayer) -> bool
-        Checks if a super troop is active for the player.
-    __add_base_details_to_entity__(data: coc.abc.BasePlayer) -> None
-        Adds the base details to the entity.
-    __add_troop_details_to_entity__(data: coc.abc.BasePlayer) -> None
-        Adds the troop details to the entity.
-    __convert_data_to_entity_list__(data: coc.abc.BasePlayer) -> Generator[Dict[str,Union[float,int,str]],None,None]
-        Converts the data object to a list of entities to insert/upsert to
-        the table.
-    __get_data__(player: str) -> Generator[Dict[str,Union[float,int,str]],None,None]
-        Returns a generator of dictionaries containing the player data to be
-        inserted/upserted to the table.
-    __update_table__(player: str) -> None
-        Updates the table for a given player.
-    scrape_clan_members(member_tags: Generator[str,None,None]) -> None:
+    scrape_clan_members(member_tags: Generator[str,None,None], coc_client_handling: bool = True) -> None:
         Scrapes the clan members and updates the table.
-    process_table() -> None
+    scrape_location_players(players: list[coc.players.RankedPlayer], coc_client_handling: bool = True) -> None:
+        Scrapes the list of players from a location and updates the table.
+    process_table(coc_client_handling: bool = True) -> None
         Updates the player table.
     """
 
     configs = CONFIG['PlayerSettings']
-    table = configs['TableName']
-    scrape_enabled = configs['ScrapeEnabled']
     players = configs['Players']
+    scrape_enabled = configs['ScrapeEnabled']
+    abandon_scrape_if_entity_exists = configs['AbandonScrapeIfEntityExists']
 
-    def __init__(self, coc_client:coc.Client, **kwargs) -> None:
+    def __init__(self, **kwargs) -> None:
         """
         Parameters
         ----------
-        coc_client : coc.Client
-            The client used to connect to the Clash of Clans API.
+        **kwargs
+            Keyword arguments to pass to the StorageHandler class.
         """
 
-        super().__init__(self.table, **kwargs)
-        self.coc_client = coc_client
+        super().__init__(table_name=self.configs['TableName'], **kwargs)
 
-    def __is_super_troop_active__(self, troop: coc.abc.DataContainer, data: coc.abc.BasePlayer) -> bool:
+    def __is_super_troop_active(self, troop: coc.abc.DataContainer, data: coc.abc.BasePlayer) -> bool:
         """
         Checks if a super troop is active for the player.
         
@@ -90,9 +69,9 @@ class PlayerTableHandler(StorageHandler):
             Whether the super troop is active or not.
         """
 
-        return True if troop in data.home_troops else False
+        return troop in data.home_troops
 
-    def __add_base_details_to_entity__(self, data: coc.abc.BasePlayer) -> None:
+    def __add_base_details_to_entity(self, data: coc.abc.BasePlayer) -> TableEntity:
         """
         Adds the base details to the entity.
 
@@ -100,54 +79,68 @@ class PlayerTableHandler(StorageHandler):
         ----------
         data : coc.abc.BasePlayer
             The player data to add to the entity.
+
+        Returns
+        -------
+        TableEntity
+            The entity corresponding to the input player and their base
+            information.
         """
+
+        entity = TableEntity()
 
         # Mandatory keys
         # PartitionKey to be defined as '{PlayerTag}-{TroopId}' when extracting troop details
-        self.entity['RowKey'] = datetime.datetime.now().strftime('%Y-%m-%d')
+        entity['RowKey'] = datetime.datetime.now().strftime('%Y-%m-%d')
 
         # Identity keys
-        self.entity['SeasonId'] = datetime.datetime.now().strftime('%Y-%m')
-        self.entity['Tag'] = try_get_attr(data, 'tag')
-        self.entity['Name'] = try_get_attr(data, 'name')
+        entity['SeasonId'] = datetime.datetime.now().strftime('%Y-%m')
+        entity['Tag'] = try_get_attr(data, 'tag')
+        entity['Name'] = try_get_attr(data, 'name')
 
         # Clan-level details
-        self.entity['Clan'] = try_get_attr(data.clan, 'tag') if try_get_attr(data, 'clan') is not None else None
-        self.entity['Role'] = try_get_attr(data, 'role')
-        self.entity['ClanRank'] = try_get_attr(data, 'clan_rank')
-        self.entity['ClanPreviousRank'] = try_get_attr(data, 'clan_previous_rank')
-        self.entity['Donations'] = try_get_attr(data, 'donations')
-        self.entity['Received'] = try_get_attr(data, 'received')
+        entity['Clan'] = try_get_attr(data.clan, 'tag') if try_get_attr(data, 'clan') is not None else None
+        entity['Role'] = try_get_attr(data, 'role')
+        entity['ClanRank'] = try_get_attr(data, 'clan_rank')
+        entity['ClanPreviousRank'] = try_get_attr(data, 'clan_previous_rank')
+        entity['Donations'] = try_get_attr(data, 'donations')
+        entity['Received'] = try_get_attr(data, 'received')
 
         # Player-level details
-        self.entity['ExpLevel'] = try_get_attr(data, 'exp_level')
-        self.entity['LeagueId'] = try_get_attr(data, 'league_id')
-        self.entity['Trophies'] = try_get_attr(data, 'trophies')
-        self.entity['VersusTrophies'] = try_get_attr(data, 'versus_trophies')
-        self.entity['ClanCapitalContributions'] = try_get_attr(data, 'clan_capital_contributions')
-        self.entity['AttackWins'] = try_get_attr(data, 'attack_wins')
-        self.entity['DefenseWins'] = try_get_attr(data, 'defense_wins')
-        self.entity['VersusAttackWins'] = try_get_attr(data, 'versus_attack_wins')
-        self.entity['BestTrophies'] = try_get_attr(data, 'best_trophies')
-        self.entity['BestVersusTrophies'] = try_get_attr(data, 'best_versus_trophies')
-        self.entity['WarStars'] = try_get_attr(data, 'war_stars')
-        self.entity['WarOptedIn'] = try_get_attr(data, 'war_opted_in')
-        self.entity['TownHall'] = try_get_attr(data, 'town_hall')
-        self.entity['TownHallWeapon'] = try_get_attr(data, 'town_hall_weapon')
-        self.entity['BuilderHall'] = try_get_attr(data, 'builder_hall')
+        entity['ExpLevel'] = try_get_attr(data, 'exp_level')
+        entity['LeagueId'] = try_get_attr(data, 'league_id')
+        entity['Trophies'] = try_get_attr(data, 'trophies')
+        entity['VersusTrophies'] = try_get_attr(data, 'versus_trophies')
+        entity['ClanCapitalContributions'] = try_get_attr(data, 'clan_capital_contributions')
+        entity['AttackWins'] = try_get_attr(data, 'attack_wins')
+        entity['DefenseWins'] = try_get_attr(data, 'defense_wins')
+        entity['VersusAttackWins'] = try_get_attr(data, 'versus_attack_wins')
+        entity['BestTrophies'] = try_get_attr(data, 'best_trophies')
+        entity['BestVersusTrophies'] = try_get_attr(data, 'best_versus_trophies')
+        entity['WarStars'] = try_get_attr(data, 'war_stars')
+        entity['WarOptedIn'] = try_get_attr(data, 'war_opted_in')
+        entity['TownHall'] = try_get_attr(data, 'town_hall')
+        entity['TownHallWeapon'] = try_get_attr(data, 'town_hall_weapon')
+        entity['BuilderHall'] = try_get_attr(data, 'builder_hall')
 
-    def __add_troop_details_to_entity(self, data: coc.abc.BasePlayer) -> Generator[Dict[str,Union[float,int,str]],None,None]:
+        return entity
+
+    def __add_troop_details_to_entity(self, base_entity: TableEntity, data: coc.abc.BasePlayer) -> Iterator[TableEntity]:
         """
-        Adds the troop details to the entity.
+        Creates a new azure.data.tables.TableEntity object for each troop
+        based on the player's base details and adds the troop details to the
+        entity.
 
         Parameters
         ----------
+        base_entity : azure.core.tables.TableEntity
+            The entity containing the base details to add the troop details to.
         data : coc.abc.BasePlayer
             The player data to add to the entity.
         
         Yields
         ------
-        Dict[str,Union[float,int,str]]
+        azure.core.tables.TableEntity
             The entity corresponding to the input player and their troop 
             information.
         """
@@ -163,20 +156,23 @@ class PlayerTableHandler(StorageHandler):
                 LOGGER.debug(f'Skipping {troop} as it is either (1) None, (2) has None id, or (3) has None level.')
                 continue
             
+            entity = base_entity.copy()
+
             # PartitionKey to be defined as '{PlayerTag}-{TroopId}'
             LOGGER.warning(f'Adding {troop} to entity.')
-            self.entity['PartitionKey'] = f"{try_get_attr(data, 'tag').lstrip('#')}-{try_get_attr(troop, 'id')}"
+            entity['PartitionKey'] = f"{try_get_attr(data, 'tag').lstrip('#')}-{try_get_attr(troop, 'id')}"
 
             # Get troop details
-            self.entity['TroopId'] = try_get_attr(troop, 'id')
-            self.entity['TroopLevel'] = try_get_attr(troop, 'level')
-            self.entity['TroopVillage'] = try_get_attr(troop, 'village')
-            self.entity['TroopTownhallMaxLevel'] = troop.get_max_level_for_townhall(data.town_hall) if hasattr(troop, 'get_max_level_for_townhall') else None
-            self.entity['TroopIsMaxForTownhall'] = try_get_attr(data, 'is_max_for_townhall')
-            self.entity['TroopIsActive'] = self.__is_super_troop_active__(troop, data) if try_get_attr(data, 'is_super_troop') is not None else None
-            yield self.entity
+            entity['TroopId'] = try_get_attr(troop, 'id')
+            entity['TroopLevel'] = try_get_attr(troop, 'level')
+            entity['TroopVillage'] = try_get_attr(troop, 'village')
+            entity['TroopTownhallMaxLevel'] = troop.get_max_level_for_townhall(data.town_hall) if hasattr(troop, 'get_max_level_for_townhall') else None
+            entity['TroopIsMaxForTownhall'] = try_get_attr(data, 'is_max_for_townhall')
+            entity['TroopIsActive'] = self.__is_super_troop_active(troop, data) if try_get_attr(data, 'is_super_troop') is not None else None
+            
+            yield entity
 
-    def __convert_data_to_entity_list__(self, data: coc.abc.BasePlayer) -> Generator[Dict[str,Union[float,int,str]],None,None]:
+    def __convert_data_to_entity_list(self, data: coc.abc.BasePlayer) -> Iterator[TableEntity]:
         """
         Converts the data to a list of entities.
 
@@ -187,15 +183,14 @@ class PlayerTableHandler(StorageHandler):
         
         Yields
         ------
-        Dict[str,Union[float,int,str]]
+        azure.core.tables.TableEntity
             All the entities corresponding to the input player.
         """
 
-        self.entity = dict()
-        self.__add_base_details_to_entity__(data)
-        yield from self.__add_troop_details_to_entity(data)
+        base_entity = self.__add_base_details_to_entity(data)
+        yield from self.__add_troop_details_to_entity(base_entity, data)
 
-    async def __get_data__(self, player: str) -> Generator[Dict[str,Union[float,int,str]],None,None]:
+    async def __get_data(self, player: str) -> Iterator[TableEntity]:
         """
         Gets the data from the API and converts to an enumerator of entities
         to be written to the table.
@@ -205,16 +200,41 @@ class PlayerTableHandler(StorageHandler):
         player : str
             The player tag to get data for.
         
-        Yields
-        ------
-        Dict[str,Union[float,int,str]]
+        Returns
+        -------
+        collections.abc.Iterator[azure.core.tables.TableEntity]
             All the entities corresponding to the input player.
         """
 
         data = await self.coc_client.get_player(player_tag=player)
-        return self.__convert_data_to_entity_list__(data)
+        return self.__convert_data_to_entity_list(data)
 
-    async def __update_table__(self, player: str) -> None:
+    def __does_player_data_exist(self, player: str) -> bool:
+        """
+        Checks if the player data exists in the table.
+
+        Parameters
+        ----------
+        player : str
+            The player tag to check if data exists for.
+        
+        Returns
+        -------
+        bool
+            True if the player data exists in the table, False otherwise.
+        """
+
+        LOGGER.debug(f'Checking if {player} exists in table {self.table_name}.')
+        
+        row_key = datetime.datetime.now().strftime('%Y-%m-%d')
+
+        query_filter = f"RowKey eq '{row_key}' and Tag eq '{player}'"
+        results = self.try_query_entities(query_filter=query_filter, retries_remaining=self.retry_entity_extraction_count, select='PartitionKey')
+        
+        has_results = bool(next(results, False))
+        return has_results
+
+    async def __update_table(self, player: str) -> None:
         """
         Updates the table with the input player's data.
 
@@ -222,13 +242,21 @@ class PlayerTableHandler(StorageHandler):
         ----------
         player : str
             The player tag to update the table with.
+
+        Returns
+        -------
+        None
         """
 
-        # TODO: How to prevent data scraping if data is already present in table?
-        entities = await self.__get_data__(player)
+        should_abandon_scrape = self.abandon_scrape_if_entity_exists and self.__does_player_data_exist(player)
+        if should_abandon_scrape:
+            LOGGER.info(f'Abandoning scrape for {player} in because it already exists.')
+            return None
+
+        entities = await self.__get_data(player)
         self.write_data_to_table(entities=entities)
 
-    async def scrape_location_players(self, players: List[coc.players.RankedPlayer]) -> None:
+    async def scrape_location_players(self, players: Iterator[coc.players.RankedPlayer], coc_client_handling: bool = True) -> None:
         """
         Scrapes the players from the input location.
 
@@ -236,18 +264,31 @@ class PlayerTableHandler(StorageHandler):
         ----------
         players : List[coc.players.RankedPlayer]
             The players to scrape.
+        coc_client_handling : bool, optional
+            (Default: True) Whether or not to handle the coc client session
+            automatically.
+
+        Returns
+        -------
+        None
         """
+
+        if coc_client_handling:
+            await self.start_coc_client_session()
         
-        LOGGER.info(f'Player table {self.table} is updating.')
+        LOGGER.info(f'Player table {self.table_name} is updating.')
         for player in players:
             try:
                 LOGGER.debug(f'Updating table with {try_get_attr(player, "tag")}\'s data.')
-                await self.__update_table__(player=try_get_attr(player, 'tag'))
+                await self.__update_table(player=try_get_attr(player, 'tag'))
             except Exception as ex:
                 LOGGER.error(f'Error updating table with {try_get_attr(player, "tag")}\'s data.')
                 LOGGER.error(ex)
 
-    async def scrape_clan_members(self, member_tags: Generator[str,None,None]) -> None:
+        if coc_client_handling:
+            await self.close_coc_client_session()
+
+    async def scrape_clan_members(self, member_tags: Iterator[str], coc_client_handling: bool = True) -> None:
         """
         Scrapes the clan members and updates the table.
 
@@ -255,30 +296,58 @@ class PlayerTableHandler(StorageHandler):
         ----------
         member_tags : Generator[str,None,None]
             The clan members' player tags for data scraping.
+        coc_client_handling : bool, optional
+            (Default: True) Whether or not to handle the coc client session
+            automatically.
+
+        Returns
+        -------
+        None
         """
 
-        LOGGER.info(f'Player table {self.table} is updating.')
+        if coc_client_handling:
+            await self.start_coc_client_session()
+
+        LOGGER.info(f'Player table {self.table_name} is updating.')
         for member_tag in member_tags:
             try:
                 LOGGER.debug(f'Updating table with player {member_tag} data.')
-                await self.__update_table__(player=member_tag)
+                await self.__update_table(player=member_tag)
             except Exception as ex:
                 LOGGER.error(f'Unable to update table with {member_tag} data.')
                 LOGGER.error(str(ex))
 
-    async def process_table(self) -> None:
+        if coc_client_handling:
+            await self.close_coc_client_session()
+
+    async def process_table(self, coc_client_handling: bool = True) -> None:
         """
         Updates the player table.
+
+        Parameters
+        ----------
+        coc_client_handling : bool, optional
+            (Default: True) Whether or not to handle the coc client session
+            automatically.
+
+        Returns
+        -------
         """
 
+        if coc_client_handling:
+            await self.start_coc_client_session()
+
         if self.scrape_enabled:
-            LOGGER.info(f'Player table {self.table} is updating.')
+            LOGGER.info(f'Player table {self.table_name} is updating.')
             for player in self.players:
                 try:
                     LOGGER.debug(f'Updating table with player {player} data.')
-                    await self.__update_table__(player)
+                    await self.__update_table(player)
                 except Exception as ex:
                     LOGGER.error(f'Unable to update table with {player} data.')
                     LOGGER.error(str(ex))
         else:
-            LOGGER.info(f'Player table {self.table} is not updated because PlayerSettings.ScrapeEnabled is {self.scrape_enabled}.')
+            LOGGER.info(f'Player table {self.table_name} is not updated because PlayerSettings.ScrapeEnabled is {self.scrape_enabled}.')
+
+        if coc_client_handling:
+                await self.close_coc_client_session()

--- a/scraper/players.py
+++ b/scraper/players.py
@@ -146,7 +146,7 @@ class PlayerTableHandler(StorageHandler):
         """
 
         inactive_super_troops = list(set(data.super_troops) - set(data.home_troops))
-        troop_list = data.heroes + data.hero_pets + data.spells + data.troops + data.builder_troops + inactive_super_troops
+        troop_list = data.heroes + data.hero_pets + data.spells + data.home_troops + data.builder_troops + inactive_super_troops
         
         for troop in troop_list:
             # Skip troop if troop object is None or its Id and Level is None

--- a/scraper/players.py
+++ b/scraper/players.py
@@ -332,6 +332,7 @@ class PlayerTableHandler(StorageHandler):
 
         Returns
         -------
+        None
         """
 
         if coc_client_handling:

--- a/scraper/players.py
+++ b/scraper/players.py
@@ -255,7 +255,7 @@ class PlayerTableHandler(StorageHandler):
 
         # TODO: How to prevent data scraping if data is already present in table?
         entities = await self.__get_data__(player)
-        self.__write_data_to_table__(entities=entities)
+        self.write_data_to_table(entities=entities)
 
     async def scrape_clan_members(self, member_tags: Generator[str,None,None]) -> None:
         """

--- a/scraper/players.py
+++ b/scraper/players.py
@@ -159,7 +159,7 @@ class PlayerTableHandler(StorageHandler):
             entity = base_entity.copy()
 
             # PartitionKey to be defined as '{PlayerTag}-{TroopId}'
-            LOGGER.warning(f'Adding {troop} to entity.')
+            LOGGER.debug(f'Adding {troop} to entity.')
             entity['PartitionKey'] = f"{try_get_attr(data, 'tag').lstrip('#')}-{try_get_attr(troop, 'id')}"
 
             # Get troop details

--- a/scraper/storage.py
+++ b/scraper/storage.py
@@ -2,12 +2,9 @@ import logging
 import coc
 
 from scraper import CONFIG
-from typing import Dict
-from typing import Union
-from typing import Optional
 from collections.abc import Iterable
 from azure.core.exceptions import ResourceExistsError
-from azure.core.exceptions import HttpResponseError
+from azure.core.exceptions import ResourceNotFoundError
 from azure.core.exceptions import ClientAuthenticationError
 from azure.core.credentials import AzureNamedKeyCredential
 from azure.data.tables import TableServiceClient
@@ -18,34 +15,66 @@ LOGGER = logging.getLogger(__name__)
 
 class StorageHandler(object):
     """
-    The storage handler object is used to connect to a table in Azure Table 
-    Storage. Data modifications on the corresponding table via inserting, 
-    upserting, and deleting entities are handled by this class.
+    The storage handler object is used to connect to the Clash of Clans API
+    client and a table in Azure Table Storage. Connection retries and data 
+    modifications on the corresponding table via inserting, upserting, and 
+    deleting entities are handled by this class.
 
     Attributes
     ----------
+    upsert_enabled : bool
+        A boolean value indicating whether or not upserting is enabled if 
+        the entity already exists in the table.
+    retry_entity_creation_enabled : bool
+        A boolean value indicating whether or not retrying entity creation
+        is enabled if a previous creation attempt has failed.
+    retry_entity_creation_count : int
+        The number of times to retry entity creation if a previous creation
+        attempt has failed.
+    retry_entity_extraction_enabled : bool
+        A boolean value indicating whether or not retrying entity extraction
+        is enabled if a previous extraction attempt has failed.
+    retry_entity_extraction_count : int
+        The number of times to retry entity extraction if a previous extraction
+        attempt has failed.
+    coc_client : coc.Client
+        The Clash of Clans API client object.
+    table_name : str
+        The name of the table in Azure Table Storage account.
     service_table_client : azure.data.tables.TableServiceClient
         The TableServiceClient object connected to the Azure Table Storage.
     table_client : azure.data.tables.TableClient
         The TableClient object connected to the table in Azure Table Storage.
-    upsert_enabled : bool
-        A boolean value indicating whether or not upserting is enabled if 
-        the entity already exists in the table.
 
     Methods
     -------
-    __connect_table_service_client__(account_name: str = None, access_key: str = None, connection_string: str = None) -> azure.data.tables.TableServiceClient
+    __connect_table_service_client(account_name: str = None, access_key: str = None, connection_string: str = None) -> azure.data.tables.TableServiceClient
         Connects to the TableServiceClient object in Azure Table Storage 
         based on the given credentials.
-    __connect_table_client__(name: str) -> azure.data.tables.TableClient
+    __connect_table_client(name: str) -> azure.data.tables.TableClient
         Connects to the TableClient object in Azure Table Storage based on
         the given table name.
-    write_data_to_table(entities: Dict[str,Union[float,int,str]]) -> None
+    __try_create_or_upsert_entity(entity: azure.data.tables.TableEntity, retries_remaining: int = 0) -> None
+        Attempts to create or upsert an entity in the table in Azure Table
+        Storage. If the entity already exists, it will be updated.
+    restart_coc_client_session() -> None
+        Restarts the Clash of Clans API client session.
+    close_coc_client_session() -> None
+        Closes the Clash of Clans API client session.
+    start_coc_client_session() -> None
+        Starts the Clash of Clans API client session.
+    write_data_to_table(entities: collections.abc.Iterable[azure.data.tables.TableEntity]) -> None
         Writes the given entities to the table in Azure Table Storage.
+    try_get_entity(partition_key: str, row_key: str, retries_remaining: int = 0, **kwargs) -> azure.data.tables.TableEntity
+        Attempts to get an entity from the table in Azure Table Storage.
     """
 
     configs = CONFIG['StorageHandlerSettings']
     upsert_enabled = configs['UpsertAtFailedPushEnabled']
+    retry_entity_creation_enabled = configs['RetryEntityCreationEnabled']
+    retry_entity_creation_count = configs['RetryEntityCreationCount']
+    retry_entity_extraction_enabled = configs['RetryEntityExtractionEnabled']
+    retry_entity_extraction_count = configs['RetryEntityExtractionCount']
 
     def __init__(
             self,
@@ -60,6 +89,10 @@ class StorageHandler(object):
         ----------
         table_name : str
             The name of the table in Azure Table Storage account.
+        coc_email : str
+            The email address of the Clash of Clans API account.
+        coc_password : str
+            The password of the Clash of Clans API account.
         account_name : str, optional
             (Default: None) The account name of the Azure Table Storage.
         access_key : str, optional
@@ -69,24 +102,25 @@ class StorageHandler(object):
         """
 
         # Clash of Clans API Client
-        self.coc_email = coc_email
-        self.coc_password = coc_password
+        self.__coc_email = coc_email
+        self.__coc_password = coc_password
         # Need to manually start coc_client session
         self.coc_client = None  
 
         # Azure Table Storage Client
         self.table_name = table_name
-        self.account_name = account_name
-        self.access_key = access_key
-        self.connection_string = connection_string
+        self.__account_name = account_name
+        self.__access_key = access_key
+        self.__connection_string = connection_string
 
-        self.service_table_client = self.__connect_table_service_client__(account_name=account_name, access_key=access_key, connection_string=connection_string)
-        self.table_client = self.__connect_table_client__(table_name)
+        self.service_table_client = self.__connect_table_service_client(account_name=account_name, access_key=access_key, connection_string=connection_string)
+        self.table_client = self.__connect_table_client(table_name)
 
-    def __connect_table_service_client__(self,
-                                         account_name: str = None,
-                                         access_key: str = None,
-                                         connection_string: str = None) -> TableServiceClient:
+    def __connect_table_service_client(
+            self,
+            account_name: str = None,
+            access_key: str = None,
+            connection_string: str = None) -> TableServiceClient:
         """
         Connects to the TableServiceClient object in Azure Table Storage
         based on the given credentials.
@@ -126,7 +160,7 @@ class StorageHandler(object):
             except:
                 LOGGER.error('Connection attempt via account name and access key failed.')
 
-    def __connect_table_client__(self, name:str) -> TableClient:
+    def __connect_table_client(self, name:str) -> TableClient:
         """
         Connects to the TableClient object in Azure Table Storage based on
         the given table name.
@@ -149,9 +183,64 @@ class StorageHandler(object):
             LOGGER.error(f'Failed to connect to table client {name}.')
             LOGGER.error(str(ex))
 
-    async def __restart_coc_client_session__(self) -> None:
+    def __try_create_or_upsert_entity(
+            self, 
+            entity: TableEntity, 
+            retries_remaining: int = 0) -> None:
+        """
+        Attempts to create or upsert the given entity in the table in Azure
+        Table Storage. If the entity already exists, it will be updated with
+        the new values. If the entity does not exist, it will be created.
+        
+        Parameters
+        ----------
+        entity : azure.data.tables.TableEntity
+            The entity to be created or upserted in the table in Azure Table Storage.
+        retries_remaining : int, optional
+            (Default: 0) The number of retries remaining to attempt to create
+            or upsert the entity in the table in Azure Table Storage.
+        
+        Returns
+        -------
+        None
+        """
+
+        assert retries_remaining >= 0, 'Retries remaining must be greater than or equal to 0.'
+
+        try:
+            self.table_client.create_entity(entity=entity)
+            LOGGER.debug('Successfully written entity to table.')
+        except ResourceExistsError:
+            LOGGER.warning(f'Entity {entity["PartitionKey"]} already exists in {self.table_client}.')
+
+            if self.upsert_enabled:
+                try:
+                    LOGGER.debug(f'Attempting upsert of entity {entity["PartitionKey"]} to {self.table_client}')
+                    self.table_client.upsert_entity(entity=entity)
+                    LOGGER.debug('Successfully upsert entity.')
+                except Exception as ex:
+                    LOGGER.error('Failed to upsert entity.')
+                    LOGGER.error(str(ex))
+        except ClientAuthenticationError as ex:
+            LOGGER.error('Client authentication error encountered, attempting re-login and retry entity creation.')
+            LOGGER.error(str(ex))
+            self.service_table_client = self.__connect_table_service_client(account_name=self.__account_name, access_key=self.__access_key, connection_string=self.__connection_string)
+            self.table_client = self.__connect_table_client(self.table_name)
+
+            if self.retry_entity_creation_enabled and retries_remaining > 0:
+                LOGGER.debug(f'Retrying entity creation {retries_remaining} more times.')
+                self.__try_create_or_upsert_entity(entity=entity, retries_remaining=retries_remaining-1)
+            else:
+                LOGGER.debug('Entity creation retry limit reached / Retry not enabled, skipping entity creation.')
+
+
+    async def restart_coc_client_session(self) -> None:
         """
         Restarts the Clash of Clans API client session.
+
+        Returns
+        -------
+        None
         """
 
         LOGGER.debug('Restarting Clash of Clans API client session.')
@@ -161,6 +250,10 @@ class StorageHandler(object):
     async def start_coc_client_session(self) -> None:
         """
         Starts a Clash of Clans API client session.
+
+        Returns
+        -------
+        None
         """
 
         if self.coc_client is not None:
@@ -170,7 +263,7 @@ class StorageHandler(object):
         try:
             LOGGER.debug('Starting Clash of Clans API client session.')
             self.coc_client = coc.Client(load_game_data=coc.LoadGameData(default=True))
-            await self.coc_client.login(email=self.coc_email, password=self.coc_password)
+            await self.coc_client.login(email=self.__coc_email, password=self.__coc_password)
         except Exception as ex:
             LOGGER.error('Failed to start Clash of Clans API client session.')
             LOGGER.error(str(ex))
@@ -178,6 +271,10 @@ class StorageHandler(object):
     async def close_coc_client_session(self) -> None:
         """
         Closes the Clash of Clans API client session.
+
+        Returns
+        -------
+        None
         """
 
         if self.coc_client is None:
@@ -188,40 +285,31 @@ class StorageHandler(object):
         await self.coc_client.close()
         self.coc_client = None 
 
-    def write_data_to_table(self, entities: Iterable[Dict[str,Union[float,int,str]]]) -> None:
+    def write_data_to_table(self, entities: Iterable[TableEntity]) -> None:
         """
         Writes the given entities to the table in Azure Table Storage.
 
         Parameters
         ----------
-        entities : Generator[Dict[str,Union[float,int,str]],None,None]
+        entities : collections.abc.Iterable[azure.data.tables.TableEntity]
             The entities to be written to the table in Azure Table Storage.
+
+        Returns
+        -------
+        None
         """
         
         LOGGER.debug(f'Writing entities to the table {self.table_client}.')
         for entity in entities:
-            try:
-                self.table_client.create_entity(entity=entity)
-                LOGGER.debug('Successfully written entity to table.')
-            except ResourceExistsError:
-                LOGGER.warning(f'Entity {entity["PartitionKey"]} already exists in {self.table_client}.')
-
-                if self.upsert_enabled:
-                    try:
-                        LOGGER.debug(f'Attempting upsert of entity {entity["PartitionKey"]} to {self.table_client}')
-                        self.table_client.upsert_entity(entity=entity)
-                        LOGGER.debug('Successfully upsert entity.')
-                    except Exception as ex:
-                        LOGGER.error('Failed to upsert entity.')
-                        LOGGER.error(str(ex))
-            except ClientAuthenticationError:
-                LOGGER.error('Client authentication error encountered, attempting login retry.')
-                self.service_table_client = self.__connect_table_service_client__(account_name=self.account_name, access_key=self.access_key, connection_string=self.connection_string)
-                self.table_client = self.__connect_table_client__(self.table_name)
-
+            self.__try_create_or_upsert_entity(entity=entity, retries_remaining=self.retry_entity_creation_count)
         LOGGER.debug('Sent all entities to table.')
 
-    def try_get_entity(self, partition_key, row_key, **kwargs) -> TableEntity:
+    def try_get_entity(
+            self, 
+            partition_key: str,
+            row_key: str,
+            retries_remaining: int = 0,
+            **kwargs) -> TableEntity:
         """
         Attempts to get the entity with the given partition key and row key.
 
@@ -231,18 +319,35 @@ class StorageHandler(object):
             The partition key of the entity to be retrieved.
         row_key : str
             The row key of the entity to be retrieved.
+        retries_remaining : int, optional
+            (Default: 0) The number of retries remaining to attempt to get
+            the entity with the given partition key and row key.
+        **kwargs
+            Additional keyword arguments to pass to the get_entity method.
 
         Returns
         -------
-        TableEntity
+        azure.data.tables.TableEntity
             The entity with the given partition key and row key.
         """
+
+        assert retries_remaining >= 0, 'Retries remaining must be greater than or equal to 0.'
 
         try:
             LOGGER.debug(f'Attempting to get entity with partition key {partition_key} and row key {row_key}.')
             return self.table_client.get_entity(partition_key=partition_key, row_key=row_key, **kwargs)
-        except HttpResponseError as ex:
-            LOGGER.error(f'Entity with partition key {partition_key} and row key {row_key} not found.')
-            LOGGER.error(str(ex))
+        except ResourceNotFoundError as ex:
+            LOGGER.debug(f'Entity with partition key {partition_key} and row key {row_key} not found.')
+            LOGGER.debug(str(ex))
             return None
-    
+        except ClientAuthenticationError as ex:
+            LOGGER.error('Client authentication error encountered, attempting re-login and retry entity extraction.')
+            LOGGER.error(str(ex))
+            self.service_table_client = self.__connect_table_service_client(account_name=self.__account_name, access_key=self.__access_key, connection_string=self.__connection_string)
+            self.table_client = self.__connect_table_client(self.table_name)
+
+            if self.retry_entity_extraction_enabled and retries_remaining > 0:
+                LOGGER.debug(f'Retrying entity extraction {retries_remaining} more times.')
+                self.try_get_entity(partition_key=partition_key, row_key=row_key, retries_remaining=retries_remaining-1, **kwargs)
+            else:
+                LOGGER.debug('Entity extraction retry limit reached / Retry not enabled, skipping entity creation.')

--- a/scraper/storage.py
+++ b/scraper/storage.py
@@ -337,7 +337,7 @@ class StorageHandler(object):
             LOGGER.debug(f'Attempting to get entity with partition key {partition_key} and row key {row_key}.')
             return self.table_client.get_entity(partition_key=partition_key, row_key=row_key, **kwargs)
         except ResourceNotFoundError as ex:
-            LOGGER.critical(f'Entity with partition key {partition_key} and row key {row_key} not found.')
+            LOGGER.debug(f'Entity with partition key {partition_key} and row key {row_key} not found.')
             LOGGER.debug(str(ex))
             return None
         except ClientAuthenticationError as ex:

--- a/scraper/storage.py
+++ b/scraper/storage.py
@@ -81,6 +81,7 @@ class StorageHandler(object):
             table_name: str,
             coc_email: str,
             coc_password: str,
+            coc_client: coc.Client = None,
             account_name: str = None, 
             access_key: str = None, 
             connection_string: str = None) -> None:
@@ -93,6 +94,8 @@ class StorageHandler(object):
             The email address of the Clash of Clans API account.
         coc_password : str
             The password of the Clash of Clans API account.
+        coc_client : coc.Client
+            (Default: None) The Clash of Clans API client object.
         account_name : str, optional
             (Default: None) The account name of the Azure Table Storage.
         access_key : str, optional
@@ -105,7 +108,7 @@ class StorageHandler(object):
         self.__coc_email = coc_email
         self.__coc_password = coc_password
         # Need to manually start coc_client session
-        self.coc_client = None  
+        self.coc_client = coc_client  
 
         # Azure Table Storage Client
         self.table_name = table_name

--- a/scraper/troops.py
+++ b/scraper/troops.py
@@ -31,7 +31,7 @@ class TroopTableHandler(StorageHandler):
     
     Methods
     -------
-    process_table() -> None
+    process_table(coc_client_handling: bool = True) -> None
         Updates the troop table.
     """
 
@@ -266,6 +266,7 @@ class TroopTableHandler(StorageHandler):
 
         query_filter = f"RowKey eq '{row_key}' and Name eq '{item}' and IsHomeVillage eq {is_home_village}"
         results = self.try_query_entities(query_filter=query_filter, retries_remaining=self.retry_entity_extraction_count, select='PartitionKey')
+        
         has_results = bool(next(results, False))
         return has_results
     
@@ -374,11 +375,6 @@ class TroopTableHandler(StorageHandler):
         coc_client_handling : bool, optional
             (Default: True) Whether or not to handle the coc client session
             automatically.
-
-        Raises
-        ------
-        coc.errors.Forbidden
-            If the client is not authorized to access the data.
 
         Returns
         -------


### PR DESCRIPTION
1. Abandons data scraping of specific entities if entity is already present in the table to save resources and prevent duplicate efforts.
2. Retries login if authentication errors come up in the middle of a scrape.